### PR TITLE
feat: add some server information in index page

### DIFF
--- a/DopplerDockerPlayground/Pages/Index.cshtml
+++ b/DopplerDockerPlayground/Pages/Index.cshtml
@@ -6,10 +6,20 @@
 	<meta charset="utf-8" />
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-	<meta name="title" content="Doppler Docker Test" />
+	<meta name="title" content="Doppler Docker Playground" />
 	<title>Doppler Docker Playground</title>
 </head>
 <body>
-	<p>Hello World!</p>
+	<h1>Doppler Docker Playground</h1>
+    <dl>
+        <dt>MachineName</dt>
+        <dd>@Model.MachineName</dd>
+        <dt>GetHostName</dt>
+        <dd>@Model.GetHostName</dd>
+        <dt>ServerId</dt>
+        <dd>@Model.ServerId</dd>
+        <dt>ServerCounter</dt>
+        <dd>@Model.ServerCounter</dd>
+    </dl>
 </body>
 </html>

--- a/DopplerDockerPlayground/Pages/Index.cshtml.cs
+++ b/DopplerDockerPlayground/Pages/Index.cshtml.cs
@@ -10,10 +10,21 @@ namespace DopplerDockerPlayground.Pages
 {
     public class IndexModel : PageModel
     {
+        private static readonly string _serverId = Guid.NewGuid().ToString();
+        public string ServerId => _serverId;
+
+        private static int _serverCounter = 0;
+        public int ServerCounter { get; }
+
+        public string MachineName { get; } = System.Environment.MachineName;
+
+        public string GetHostName { get; } = System.Net.Dns.GetHostName();
+
         private readonly ILogger<IndexModel> _logger;
         public IndexModel(ILogger<IndexModel> logger)
         {
             _logger = logger;
+            ServerCounter = System.Threading.Interlocked.Add(ref _serverCounter, 1);
         }
 
         public void OnGet()

--- a/DopplerDockerPlaygroundTest/IndexTests.cs
+++ b/DopplerDockerPlaygroundTest/IndexTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DopplerDockerPlaygroundTest
+{
+    public class IndexTests : IClassFixture<WebApplicationFactory<DopplerDockerPlayground.Startup>>
+    {
+        private readonly WebApplicationFactory<DopplerDockerPlayground.Startup> _factory;
+
+        public IndexTests(WebApplicationFactory<DopplerDockerPlayground.Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Theory]
+        [InlineData("/")]
+        public async Task Index_should_increment_ServerCounter_in_consecutive_requests(string url)
+        {
+            // Arrange
+            var serverCounterRegex = new Regex(@"<dt>ServerCounter</dt>\s+<dd>(\d+)</dd>");
+            int ExtractServerCounter(string str) =>
+                int.Parse(serverCounterRegex.Match(str).Groups[1].Value);
+
+            var client = _factory.CreateClient();
+
+            var firstResponse = await client.GetAsync(url);
+            var firstContent = await firstResponse.Content.ReadAsStringAsync();
+            Assert.Matches(serverCounterRegex, firstContent);
+            var firstServerCounter = ExtractServerCounter(firstContent);
+
+            // Act
+            var secondResponse = await client.GetAsync(url);
+
+            // Assert
+            var secondContent = await secondResponse.Content.ReadAsStringAsync();
+            Assert.Matches(serverCounterRegex, secondContent);
+            var secondServerCounter = ExtractServerCounter(secondContent);
+            Assert.Equal(firstServerCounter + 1, secondServerCounter);
+
+            // Act
+            var thirdResponse = await client.GetAsync(url);
+
+            // Assert
+            var thirdContent = await thirdResponse.Content.ReadAsStringAsync();
+            Assert.Matches(serverCounterRegex, thirdContent);
+            var thirdServerCounter = ExtractServerCounter(thirdContent);
+            Assert.Equal(firstServerCounter + 2, thirdServerCounter);
+        }
+    }
+}


### PR DESCRIPTION
Hi team, these changes allow me to experiment with a swarm with multiple services instances.

The results are simillar than these:

```html
<h1>Doppler Docker Playground</h1>
<dl>
  <dt>MachineName</dt>
  <dd>MS-MacBook-Pro-2</dd>

  <dt>GetHostName</dt>
  <dd>MS-MacBook-Pro-2.local</dd>

  <dt>ServerId</dt>
  <dd>f4905c3f-f14a-4f6a-84a0-962ff754084b</dd>

  <dt>ServerCounter</dt>
  <dd>1</dd>
</dl>
```