### PR TITLE
Refactor ServerStatus as DI singleton

### DIFF
--- a/DopplerDockerPlayground/Pages/Index.cshtml.cs
+++ b/DopplerDockerPlayground/Pages/Index.cshtml.cs
@@ -10,21 +10,23 @@ namespace DopplerDockerPlayground.Pages
 {
     public class IndexModel : PageModel
     {
-        private static readonly string _serverId = Guid.NewGuid().ToString();
-        public string ServerId => _serverId;
+        public string ServerId { get; }
 
-        private static int _serverCounter = 0;
         public int ServerCounter { get; }
 
-        public string MachineName { get; } = System.Environment.MachineName;
+        public string MachineName { get; }
 
-        public string GetHostName { get; } = System.Net.Dns.GetHostName();
+        public string GetHostName { get; }
 
         private readonly ILogger<IndexModel> _logger;
-        public IndexModel(ILogger<IndexModel> logger)
+
+        public IndexModel(ILogger<IndexModel> logger, ServerStatus serverStatus)
         {
             _logger = logger;
-            ServerCounter = System.Threading.Interlocked.Add(ref _serverCounter, 1);
+            ServerId = serverStatus.ServerId;
+            ServerCounter = serverStatus.GetAndIncrementCounter();
+            MachineName = serverStatus.MachineName;
+            GetHostName = serverStatus.GetHostName;
         }
 
         public void OnGet()

--- a/DopplerDockerPlayground/ServerStatus.cs
+++ b/DopplerDockerPlayground/ServerStatus.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Net;
+using System.Threading;
+
+namespace DopplerDockerPlayground
+{
+    public class ServerStatus
+    {
+        public string ServerId { get; } = Guid.NewGuid().ToString();
+        public string MachineName { get; } = Environment.MachineName;
+        public string GetHostName { get; } = Dns.GetHostName();
+        int _serverCounter = 0;
+        public int GetAndIncrementCounter() => Interlocked.Add(ref _serverCounter, 1);
+    }
+}

--- a/DopplerDockerPlayground/Startup.cs
+++ b/DopplerDockerPlayground/Startup.cs
@@ -24,6 +24,7 @@ namespace DopplerDockerPlayground
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddRazorPages();
+            services.AddSingleton<ServerStatus>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/DopplerDockerPlaygroundTest/IndexTests.cs
+++ b/DopplerDockerPlaygroundTest/IndexTests.cs
@@ -30,6 +30,7 @@ namespace DopplerDockerPlaygroundTest
             var firstContent = await firstResponse.Content.ReadAsStringAsync();
             Assert.Matches(serverCounterRegex, firstContent);
             var firstServerCounter = ExtractServerCounter(firstContent);
+            Assert.Equal(1, firstServerCounter);
 
             // Act
             var secondResponse = await client.GetAsync(url);
@@ -38,7 +39,7 @@ namespace DopplerDockerPlaygroundTest
             var secondContent = await secondResponse.Content.ReadAsStringAsync();
             Assert.Matches(serverCounterRegex, secondContent);
             var secondServerCounter = ExtractServerCounter(secondContent);
-            Assert.Equal(firstServerCounter + 1, secondServerCounter);
+            Assert.Equal(2, secondServerCounter);
 
             // Act
             var thirdResponse = await client.GetAsync(url);
@@ -47,7 +48,7 @@ namespace DopplerDockerPlaygroundTest
             var thirdContent = await thirdResponse.Content.ReadAsStringAsync();
             Assert.Matches(serverCounterRegex, thirdContent);
             var thirdServerCounter = ExtractServerCounter(thirdContent);
-            Assert.Equal(firstServerCounter + 2, thirdServerCounter);
+            Assert.Equal(3, thirdServerCounter);
         }
     }
 }


### PR DESCRIPTION
The tests were failing randomly. It fix the issue using a DI singleton to represent the server status in place of using static fields.