### PR TITLE
fix(build): render the right version number in version.txt

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,11 +24,7 @@ pipeline {
             }
             steps {
                 // It is a temporal step, in the future we will only publish final version images
-                sh '''docker build \\
-                    -t "fromdoppler/doppler-docker-playground:production-commit-${GIT_COMMIT}" \\
-                    --build-arg version=production-commit-${GIT_COMMIT} \\
-                    .'''
-                sh 'sh ./publish-commit-image-to-dockerhub.sh production ${GIT_COMMIT} v0.0.0 commit-${GIT_COMMIT}'
+                sh 'sh build-n-publish.sh production ${GIT_COMMIT} v0.0.0 commit-${GIT_COMMIT}'
             }
         }
         stage('Publish final version images') {
@@ -38,11 +34,7 @@ pipeline {
                 }
             }
             steps {
-                sh '''docker build \\
-                    -t "fromdoppler/doppler-docker-playground:production-commit-${GIT_COMMIT}" \\
-                    --build-arg version=production-${TAG_NAME}+${GIT_COMMIT} \\
-                    .'''
-                sh 'sh publish-commit-image-to-dockerhub.sh production ${GIT_COMMIT} ${TAG_NAME}'
+                sh 'sh build-n-publish.sh production ${GIT_COMMIT} ${TAG_NAME}'
             }
         }
         stage('Generate version') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
             steps {
                 sh '''docker build \\
                     -t "fromdoppler/doppler-docker-playground:production-commit-${GIT_COMMIT}" \\
-                    --build-arg version=production-commit-${GIT_COMMIT} \\
+                    --build-arg version=production-${TAG_NAME}+${GIT_COMMIT} \\
                     .'''
                 sh 'sh publish-commit-image-to-dockerhub.sh production ${GIT_COMMIT} ${TAG_NAME}'
             }

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -99,22 +99,28 @@ else
   preReleasePrefix=""
 fi
 # endregion Ugly code to deal with versions
+imageName=fromdoppler/doppler-docker-playground
+canonicalTag=${preReleasePrefix}${environment}-${versionFullForTag}
 
-docker tag fromdoppler/doppler-docker-playground:${environment}-commit-${commit} fromdoppler/doppler-docker-playground:${preReleasePrefix}${environment}
-docker tag fromdoppler/doppler-docker-playground:${environment}-commit-${commit} fromdoppler/doppler-docker-playground:${preReleasePrefix}${environment}-${versionMayor}
-docker tag fromdoppler/doppler-docker-playground:${environment}-commit-${commit} fromdoppler/doppler-docker-playground:${preReleasePrefix}${environment}-${versionMayorMinor}
-docker tag fromdoppler/doppler-docker-playground:${environment}-commit-${commit} fromdoppler/doppler-docker-playground:${preReleasePrefix}${environment}-${versionMayorMinorPatch}
-docker tag fromdoppler/doppler-docker-playground:${environment}-commit-${commit} fromdoppler/doppler-docker-playground:${preReleasePrefix}${environment}-${versionMayorMinorPatchPre}
-docker tag fromdoppler/doppler-docker-playground:${environment}-commit-${commit} fromdoppler/doppler-docker-playground:${preReleasePrefix}${environment}-${versionFullForTag}
+docker build \
+    -t ${imageName}:${canonicalTag} \
+    --build-arg version=${preReleasePrefix}${environment}-${versionFull} \
+    .
+
+docker tag ${imageName}:${canonicalTag} ${imageName}:${preReleasePrefix}${environment}
+docker tag ${imageName}:${canonicalTag} ${imageName}:${preReleasePrefix}${environment}-${versionMayor}
+docker tag ${imageName}:${canonicalTag} ${imageName}:${preReleasePrefix}${environment}-${versionMayorMinor}
+docker tag ${imageName}:${canonicalTag} ${imageName}:${preReleasePrefix}${environment}-${versionMayorMinorPatch}
+docker tag ${imageName}:${canonicalTag} ${imageName}:${preReleasePrefix}${environment}-${versionMayorMinorPatchPre}
 
 # TODO: It could break concurrent deployments with different docker accounts
 docker login -u="$DOCKER_WRITTER_USERNAME" -p="$DOCKER_WRITTER_PASSWORD"
 
 # TODO: push all tags
 
-docker push fromdoppler/doppler-docker-playground:${preReleasePrefix}${environment}
-docker push fromdoppler/doppler-docker-playground:${preReleasePrefix}${environment}-${versionMayor}
-docker push fromdoppler/doppler-docker-playground:${preReleasePrefix}${environment}-${versionMayorMinor}
-docker push fromdoppler/doppler-docker-playground:${preReleasePrefix}${environment}-${versionMayorMinorPatch}
-docker push fromdoppler/doppler-docker-playground:${preReleasePrefix}${environment}-${versionMayorMinorPatchPre}
-docker push fromdoppler/doppler-docker-playground:${preReleasePrefix}${environment}-${versionFullForTag}
+docker push ${imageName}:${canonicalTag}
+docker push ${imageName}:${preReleasePrefix}${environment}-${versionMayorMinorPatchPre}
+docker push ${imageName}:${preReleasePrefix}${environment}-${versionMayorMinorPatch}
+docker push ${imageName}:${preReleasePrefix}${environment}-${versionMayorMinor}
+docker push ${imageName}:${preReleasePrefix}${environment}-${versionMayor}
+docker push ${imageName}:${preReleasePrefix}${environment}


### PR DESCRIPTION
Sorry team, 

I forgot to apply this change in the previous PR.

The idea is having the right version number in the `version.txt` file, like in WebApp:

![image](https://user-images.githubusercontent.com/1157864/68947286-d7c7bd80-0793-11ea-9d3b-3e594287c4f1.png)
